### PR TITLE
Implementation of Language Switch and Portuguese Translation

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -38,6 +38,24 @@ img {
 	-webkit-app-region: drag;
 }
 
+#select-language {
+    background: transparent;
+}
+
+.button-language {
+	max-width: 200px;
+}
+
+.button-language:hover {
+	color: red;
+}
+
+.button-language h1 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .overflow-hidden {
 	overflow: hidden;
 }

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,0 +1,14 @@
+const i18next = require("i18next");
+const enTranslations = require("./locales/en.json");
+const ptBRTranslations = require("./locales/pt-BR.json");
+
+i18next.init({
+  lng: "en", // Default language
+  debug: true,
+  resources: {
+    en: { translation: enTranslations },
+    ptBR: { translation: ptBRTranslations },
+  },
+});
+
+module.exports = i18next;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,57 @@
+{
+  "applicationInformation.appVersion": "App version:",
+  "applicationInformation.author": "Author:",
+  "applicationInformation.contributors": "Contributors:",
+  "applicationInformation.description": "Description:",
+  "applicationInformation.descriptionMessage": "Epub Reader Application built with ElectronJS",
+  "applicationInformation.gitRepository": "Git Repository:",
+
+  "bookInformation.title": "Title:",
+  "bookInformation.author": "Author:",
+  "bookInformation.language": "Language:",
+  "bookInformation.year": "Year Edition:",
+  "bookInformation.pages": "Pages:",
+  "bookInformation.applyEdit": "Apply edit",
+
+  "dropArea.dropFileHere": "Drop file here",
+
+  "mainNavbar.library": "Library",
+  "mainNavbar.saveThisPage": "Save this page",
+
+  "settingsMenu.settings": "Settings",
+  "settingsMenu.appInformation": "App information",
+
+  "sidebarSettings.BackToDashboard": "Back to dashboard",
+  "sidebarSettings.searchBooks": "Search books...",
+
+  "readingSettings.typeface": "Typeface:",
+  "readingSettings.default": "Default",
+  "readingSettings.colorStyle": "Color Style:",
+  "readingSettings.layout": "Layout:",
+
+  "currentPageOf": " of ",
+
+  "allBooksRightArrow": "All Books ->",
+
+  "bookSortings.sorting": "Sorting",
+  "bookSortings.sortBy": "Sort by: ",
+  "bookSortings.lastRead": "Last Read",
+  "bookSortings.alphabetically": "Alphabetically",
+  "bookSortings.lastOpened": "Last Opened",
+  "bookSortings.applyChanges": "Apply changes",
+
+  "keepReadingButton.keepReading": "Keep reading",
+  "keepReadingButton.startReading": "Start reading",
+
+  "dictionaryPopup.highlightSomeText": "Highlight some text to know his definition!",
+  "dictionaryPopup.rembemberToSearchFor": "Rembember to search for ",
+  "dictionaryPopup.onlyOneWordAtATime": "only one word at a time",
+  "dictionaryPopup.noPageSaved": "no page saved",
+
+  "noPreviewAvailable": "No preview available.",
+  "addBooksByClickingPlusButton": "Add books by clicking the \"+\" button.",
+  "new": "NEW",
+
+  "library.noBooksFound": "No books found.",
+  "library.youMayTryRemoveTheSearch": "You may try remove the search."
+}

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1,0 +1,57 @@
+{
+  "applicationInformation.appVersion": "Versão do aplicativo:",
+  "applicationInformation.author": "Autor:",
+  "applicationInformation.contributors": "Colaboradores:",
+  "applicationInformation.description": "Descrição:",
+  "applicationInformation.descriptionMessage": "Um Leitor de Epub construído com ElectronJS",
+  "applicationInformation.gitRepository": "Repositório Git:",
+
+  "bookInformation.title": "Título:",
+  "bookInformation.author": "Autor:",
+  "bookInformation.language": "Idioma:",
+  "bookInformation.year": "Ano:",
+  "bookInformation.pages": "Páginas:",
+  "bookInformation.applyEdit": "Aplicar edição",
+
+  "dropArea.dropFileHere": "Solte o arquivo aqui",
+
+  "mainNavbar.library": "Biblioteca",
+  "mainNavbar.saveThisPage": "Salvar esta página",
+
+  "settingsMenu.settings": "Configurações",
+  "settingsMenu.appInformation": "Sobre o aplicativo",
+
+  "sidebarSettings.BackToDashboard": "Voltar ao painel",
+  "sidebarSettings.searchBooks": "Pesquisar livros...",
+
+  "readingSettings.typeface": "Tipo de letra/Fonte:",
+  "readingSettings.default": "Padrão",
+  "readingSettings.colorStyle": "Estilo de Cor:",
+  "readingSettings.layout": "Formato/Layout:",
+
+  "currentPageOf": " de ",
+
+  "allBooksRightArrow": "Todos os Livros ->",
+
+  "bookSortings.sorting": "Ordem",
+  "bookSortings.sortBy": "Ordenar por: ",
+  "bookSortings.lastRead": "Última Leitura",
+  "bookSortings.alphabetically": "Alfabeticamente",
+  "bookSortings.lastOpened": "Última Abertura",
+  "bookSortings.applyChanges": "Aplicar alterações",
+
+  "keepReadingButton.keepReading": "Continuar lendo",
+  "keepReadingButton.startReading": "Começar a ler",
+
+  "dictionaryPopup.highlightSomeText": "Destaque algum texto para saber seu significado!",
+  "dictionaryPopup.rembemberToSearchFor": "Lembre-se de pesquisar ",
+  "dictionaryPopup.onlyOneWordAtATime": "apenas uma palavra por vez",
+  "dictionaryPopup.noPageSaved": "nenhuma página salva",
+
+  "noPreviewAvailable": "Nenhuma pré-visualização disponível.",
+  "addBooksByClickingPlusButton": "Adicione livros clicando no botão \"+\".",
+  "new": "NOVO",
+  
+  "library.noBooksFound": "Nenhum livro encontrado.",
+  "library.youMayTryRemoveTheSearch": "Você pode tentar remover a pesquisa."
+}

--- a/src/js/book/book.js
+++ b/src/js/book/book.js
@@ -198,7 +198,7 @@ var loadDictionary = async function (){
         $('#dictionary-popup').html(finalHtml);
     } else {
         // No selection text
-        $('#dictionary-popup').html('<h1 class="main-text text-sb" style="text-align: center; font-size: 14px;">Highlight some text to know his definition!</h1>')
+        $('#dictionary-popup').html(`<h1 class="main-text text-sb" style="text-align: center; font-size: 14px;">${window.i18n.t("dictionaryPopup.highlightSomeText")}</h1>`)
     }
 }
 
@@ -274,7 +274,7 @@ async function getHtmlEnglishDictionary(selection_text){
         }
     } else {
         // No match text
-        finalHtml += `<div class="dictionary-definition-box flex-column"><h1 class="main-text text-sb" style="font-size: 20px; padding-top: 10px;">${multiple_definitions.title}</h1><div class="horizontal-divider-05 m-t-10 m-b-10 bg-black"></div><h2 class="main-text">${multiple_definitions.message}<br><br>Rembember to search for <u>only one word at a time</u></h2></div>`;
+        finalHtml += `<div class="dictionary-definition-box flex-column"><h1 class="main-text text-sb" style="font-size: 20px; padding-top: 10px;">${multiple_definitions.title}</h1><div class="horizontal-divider-05 m-t-10 m-b-10 bg-black"></div><h2 class="main-text">${multiple_definitions.message}<br><br>${window.i18n.t("dictionaryPopup.rembemberToSearchFor")}<u>${window.i18n.t("dictionaryPopup.rembemberToSearchFor")}</u></h2></div>`;
     }
     return finalHtml
 }
@@ -325,7 +325,7 @@ async function loadSavedPages(saved_pages){
             `)
         })
     } else {
-        $('#book-saved-pages').html('<h1 class="main-text text-small op-5" style="text-align: center;">no page saved</h1>');
+        $('#book-saved-pages').html(`<h1 class="main-text text-small op-5" style="text-align: center;">${window.i18n.t("dictionaryPopup.noPageSaved")}</h1>`);
     }
 }
 async function handleSavePage() {
@@ -451,6 +451,12 @@ function applyThemeStyles(theme) {
     const dictionaryPopupH2 = $('#dictionary-popup h2')
     const dictionaryPopupOlLi = $('#dictionary-popup ol li')
 
+    // Language Menu
+    const languageMenuOpenText = $('#language-menu-open h1');
+    const languageMenuArrow = $('#language-menu-open svg line');
+    const languageMenu = $('#language-menu');
+    const languageMenuButtons = $('#menu-open-languages .button-language h1');
+
     // Reset classes
     backgroundElements.removeClass('page-color-style-brown-bg page-color-style-dark-bg');
     iconElements.removeClass('page-color-style-brown-color page-color-style-dark-color');
@@ -471,15 +477,20 @@ function applyThemeStyles(theme) {
     typefaceSectionSVG.css('fill', 'black');
     selectFontFamily.css('background-color', 'white');
 
-    bookInfoH1.css('color', 'black')
-    bookInfoSpan.css('color', 'black')
+    bookInfoH1.css('color', 'black');
+    bookInfoSpan.css('color', 'black');
 
-    bookChaptersH1.css('color', 'black')
+    bookChaptersH1.css('color', 'black');
 
-    bookSavedPagesH1.css('color', 'black')
-    bookSavedPagesH2.css('color', 'black')
-    bookSaveButton.css('fill', 'black')
-    bookUnsaveButton.css('background-color', '#E3B230')
+    bookSavedPagesH1.css('color', 'black');
+    bookSavedPagesH2.css('color', 'black');
+    bookSaveButton.css('fill', 'black');
+    bookUnsaveButton.css('background-color', '#E3B230');
+
+    languageMenu.removeClass('page-color-style-brown-bg page-color-style-dark-bg');
+    languageMenuOpenText.css('color', '');
+    languageMenuArrow.css('stroke', '');
+    languageMenuButtons.css('color', '');
 
     /*dictionaryPopupH1.css('color', 'black')
     dictionaryPopupH2.css('color', 'black')
@@ -520,6 +531,11 @@ function applyThemeStyles(theme) {
             /*dictionaryPopupH1.css('color', '#5B4636')
             dictionaryPopupH2.css('color', '#5B4636')
             dictionaryPopupOlLi.css('color', '#5B4636')*/
+
+            languageMenu.addClass('page-color-style-brown-bg');
+            languageMenuOpenText.css('color', '#5B4636');
+            languageMenuArrow.css('stroke', '#5B4636');
+            languageMenuButtons.css('color', '#5B4636');
             break;
         case "dark":
             book_rendition.themes.default({ body: { 'color': 'white' } });
@@ -555,10 +571,20 @@ function applyThemeStyles(theme) {
             /*dictionaryPopupH1.css('color', 'white')
             dictionaryPopupH2.css('color', 'white')
             dictionaryPopupOlLi.css('color', 'white')*/
+
+            languageMenu.addClass('page-color-style-dark-bg');
+            languageMenuOpenText.css('color', 'white');
+            languageMenuArrow.css('stroke', 'white');
+            languageMenuButtons.css('color', 'white');
             break;
         default: // Default to light theme
             book_rendition.themes.default({ body: { 'color': 'black' } });
             textElements.css('color', 'black');
+
+            languageMenu.css('background-color', 'white');
+            languageMenuOpenText.css('color', 'black');
+            languageMenuArrow.css('stroke', 'black');
+            languageMenuButtons.css('color', 'black');
     }
 }
 

--- a/src/js/dashboard/dashboard.js
+++ b/src/js/dashboard/dashboard.js
@@ -35,7 +35,8 @@ async function loadHeroSection(books_json) {
 		// Check cover exists and return path 
         const bookCover = await window.bookConfig.ensureBookCoverExistsAndReturn(bookFolderName, coverPath)
 
-        var keepReadingText = bookOpened ? 'Keep reading' : 'Start reading';
+        // var keepReadingText = bookOpened ? 'Keep reading' : 'Start reading';
+        var keepReadingText = bookOpened ? window.i18n.t('keepReadingButton.keepReading') : window.i18n.t('keepReadingButton.startReading');
         $('#hero-section-content')
             .html(`
             <div id="hero-section-image-cover" class="flex justify-center items-center overflow-hidden select-none w-[140px] h-[213px]">
@@ -49,7 +50,7 @@ async function loadHeroSection(books_json) {
         `)
         $('#hero-section-image-background').css('background-image', `linear-gradient(180deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 100%), url(${bookCover}`);
     } else {
-        $('#hero-section-content').html('<h2 class="main-text text-white text-center">No preview available.<br>Add books by clicking the "+" button</h2>')
+        $('#hero-section-content').html(`<h2 class="main-text text-white text-center">${window.i18n.t("noPreviewAvailable")}<br>${window.i18n.t("addBooksByClickingPlusButton")}</h2>`)
         $('#hero-section-image-background').css({ 'background-image': 'none', 'background-color': 'rgb(20, 20, 20)' });
     }
     $('#hero-section-loading-animation').addClass('hidden')
@@ -82,7 +83,7 @@ async function loadBooksSection(books_json) {
                         <img class="w-full h-full" src="${bookCover}">
                     </div>
                     <div class="new-book-box drop-shadow-lg" style="background-color: rgb(${dominantRGBValue}); display: ${already_read}">
-                        <h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">NEW</h1>
+                        <h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">${window.i18n.t("new")}</h1>
                     </div>
                     <div class="book-delete-icon cursor-pointer" onclick="event.stopPropagation(); deleteEpubBookHandler($(this).parent().data('folderbookcode'));">
                         <svg class="cursor-pointer" width="10" height="10" viewBox="0 0 15 1" xmlns="http://www.w3.org/2000/svg">
@@ -98,7 +99,7 @@ async function loadBooksSection(books_json) {
                 $('#section-book-preview').append('<div class="book-box"></div>')
             }
         }
-		$('#section-book-preview').append('<div class="book-box"><a id="see-all-books" href="library.html" class="main-text font-bold transition py-5 px-[30px] rounded-[10px] hover:bg-black hover:text-white">All Books -></a></div>')
+		$('#section-book-preview').append(`<div class="book-box"><a id="see-all-books" href="library.html" class="main-text font-bold transition py-5 px-[30px] rounded-[10px] hover:bg-black hover:text-white" data-i18n="allBooksRightArrow">All Books -></a></div>`)
     }
     $('.circle-loading-logo').css('opacity', '0');
 }

--- a/src/js/general/navbarHandler.js
+++ b/src/js/general/navbarHandler.js
@@ -22,6 +22,9 @@ $(window).on('load', async function () {
     $('#settings-menu-open').on('click', function(){
         $('#settings-menu').toggleClass('hidden');
     })
+    $('#language-menu-open').on('click', function(){
+        $('#language-menu').toggleClass('hidden');
+    })
     $("body").on('click', function (e) {
         // iframe click doesn't work, need to be added/fixed
         if (!$(e.target).is('#settings-menu-open') && // Check clicking popup icon

--- a/src/js/general/rendererI18n.js
+++ b/src/js/general/rendererI18n.js
@@ -1,0 +1,36 @@
+// Get the language from localStorage; "en" is the default language
+const language = localStorage.getItem("language") || "en";
+const languageMenu = document.querySelector("#language-menu-open > h1")
+const languagesObject = {
+  "en": "EN",
+  "ptBR": "PT-BR"
+};
+
+const applyTranslations = () => {
+  // Elements with visible text
+  document.querySelectorAll(" [data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    el.innerText = window.i18n.t(key);
+  });
+
+  // Elements with placeholder text
+  document.querySelectorAll(" [data-i18n-placeholder]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-placeholder");
+    el.placeholder = window.i18n.t(key);
+  });
+
+  // Elements with text in value
+  document.querySelectorAll(" [data-i18n-value]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-value");
+    el.value = window.i18n.t(key);
+  });
+};
+
+function defineCurrentLanguage(languageValue) {
+  localStorage.setItem("language", languageValue);
+  // selectLanguage.value = languageValue;
+  languageMenu.textContent = languagesObject[languageValue];
+  window.i18n.changeLanguage(languageValue, () => applyTranslations());
+}
+
+defineCurrentLanguage(language);

--- a/src/js/library/library.js
+++ b/src/js/library/library.js
@@ -37,9 +37,9 @@ var loadBooks = async function (books_json_not_sorted){
     } else {
         $('.circle-loading-logo').css('opacity', '0');
         if (isSearchingSomething) {
-            $('#book-section-grid').html('<h2 class="no-book-text main-text text-align-center">No books found.<br>You may try remove the search</h2>');    
+            $('#book-section-grid').html(`<h2 class="no-book-text main-text text-align-center">${window.i18n.t("library.noBooksFound")}<br>${window.i18n.t("library.youMayTryRemoveTheSearch")}</h2>`);    
         } else {
-            $('#book-section-grid').html('<h2 class="no-book-text main-text text-align-center">No preview available.<br>Add books by clicking the "+" button</h2>');
+            $('#book-section-grid').html(`<h2 class="no-book-text main-text text-align-center">${window.i18n.t("noPreviewAvailable")}<br>${window.i18n.t("addBooksByClickingPlusButton")}</h2>`);
         }
     }
 }
@@ -69,7 +69,7 @@ async function loadBooksAction(ordered_books, dominantRGBValue) {
                         <img class="w-full h-full" src="${bookCover}">
                     </div>
                     <div class="new-book-box drop-shadow-lg" style="background-color: rgb(${dominantRGBValue}); display: ${already_read}">
-                        <h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">NEW</h1>
+                        <h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">${window.i18n.t("new")}</h1>
                     </div>
                     <div class="book-delete-icon cursor-pointer" onclick="event.stopPropagation(); deleteEpubBookHandler($(this).parent().data('folderbookcode'));">
                         <svg class="cursor-pointer" width="10" height="10" viewBox="0 0 15 1" xmlns="http://www.w3.org/2000/svg">
@@ -116,7 +116,7 @@ async function loadBooksAction(ordered_books, dominantRGBValue) {
 						<img class="w-full h-full" src="${bookCover}">
 					</div>
 					<div class="new-book-box drop-shadow-lg" style="background-color: rgb(${dominantRGBValue}); display: ${already_read}">
-						<h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">NEW</h1>
+						<h1 class="main-text text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.35)] font-bold">${window.i18n.t("new")}</h1>
 					</div>
 					<div class="book-delete-icon cursor-pointer" onclick="event.stopPropagation(); deleteEpubBookHandler($(this).parent().data('folderbookcode'));">
 						<svg class="cursor-pointer" width="10" height="10" viewBox="0 0 15 1" xmlns="http://www.w3.org/2000/svg">
@@ -134,7 +134,7 @@ async function loadBooksAction(ordered_books, dominantRGBValue) {
 			}
 		}
 	} else {
-		$('#book-section-grid').html('<h2 class="no-book-text main-text text-align-center">No books found.<br>You may try remove the search</h2>');
+		$('#book-section-grid').html('<h2 class="no-book-text main-text text-align-center">${window.i18n.t("library.noBooksFound")}<br>${window.i18n.t("library.youMayTryRemoveTheSearch")}</h2>');
 	}
 	$('.circle-loading-logo').css('opacity', '0');
 }

--- a/src/pages/book.html
+++ b/src/pages/book.html
@@ -18,6 +18,7 @@
     <script src="../js/book/book.js"></script>
     <script src="../js/book/bookNavbarHandler.js"></script>
     <script src="../js/general/dictionaryApi.js"></script>
+    <script src="../js/general/rendererI18n.js" defer></script>
 </head>
 
 <body>
@@ -27,7 +28,31 @@
             <div class="flex-row flex-v-center gap-30 no-drag">
                 <a href="library.html" id="libraryNavBtn"
                     class="main-text text-color-black text-sb cursor-pointer text-decoration-none"
-                    onclick="saveBeforeClose();">Library</a>
+                    onclick="saveBeforeClose();" data-i18n="mainNavbar.library">Library</a>
+                <div class="vertical-divider-05"></div>
+                <div class="flex flex-col relative">
+					<div id="language-menu-open" class="flex flex-row items-center cursor-pointer">
+						<h1 class="main-text mr-1 font-semibold">EN</h1>
+						<svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="black" stroke-linecap="round" />
+							<line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="black" stroke-linecap="round" />
+						</svg>
+					</div>
+					<div id="language-menu" class="p-6 mt-10 hidden absolute z-[10] flex flex-col gap-7 rounded-md bg-[#121212] shadow-md overflow-hidden w-fit">
+						<div id="menu-open-languages" class="flex flex-col items-center transition opacity-80 hover:opacity-100 cursor-pointer">
+                            <div>
+                                <button class="button-language" onclick="defineCurrentLanguage('en')">
+                                    <h1 class="main-text text-white ml-2">EN</h1>
+                                </button>
+                            </div>
+                            <div>
+                                <button class="button-language" onclick="defineCurrentLanguage('ptBR')">
+                                    <h1 class="main-text text-white ml-2">PT-BR</h1>
+                                </button>
+                            </div>
+						</div>
+					</div>
+				</div>
                 <div class="vertical-divider-05"></div>
                 <div class="flex-row flex-v-center gap-30">
                     <div class="flex-column" style="position: relative;">
@@ -72,7 +97,7 @@
                                         d="M1.84129 0.75H13.1391C13.7319 0.75 14.2304 1.2285 14.2304 1.84129L14.2304 18.5454C14.2304 18.5456 14.2304 18.5457 14.2304 18.5458C14.2288 19.1579 13.4557 19.5054 12.986 19.0306L12.9831 19.0277L8.6814 14.7272C8.04218 14.0681 6.93821 14.0681 6.29899 14.7272L1.99733 19.0277L1.9944 19.0306C1.5249 19.5052 0.751938 19.1582 0.75 18.546V1.84129C0.75 1.2285 1.24849 0.75 1.84129 0.75Z"
                                         stroke="white" stroke-width="1.5" />
                                 </svg>
-                                <h1 class="main-text text-sb">Save this page</h1>
+                                <h1 class="main-text text-sb" data-i18n="mainNavbar.saveThisPage">Save this page</h1>
                             </div>
                             <div id="book-saved-pages" class="flex-column gap-15">
                                 <!-- <div class="book-saved-box cursor-pointer flex-row flex-v-center">
@@ -107,27 +132,27 @@
                         <div id="book-info" class="book-navbar-popup">
                             <div class="flex-column" style="gap: 10px;">
                                 <div class="flex-row">
-                                    <h1 class="main-text m-r-10">Title:</h1><span id="book-info-title"
+                                    <h1 class="main-text m-r-10" data-i18n="bookInformation.title">Title:</h1><span id="book-info-title"
                                         class="main-text text-sb"></span>
                                 </div>
                                 <div class="horizontal-divider-05" style="opacity: .1; background-color: black;"></div>
                                 <div class="flex-row">
-                                    <h1 class="main-text m-r-10">Author:</h1><span id="book-info-author"
+                                    <h1 class="main-text m-r-10" data-i18n="bookInformation.author">Author:</h1><span id="book-info-author"
                                         class="main-text text-sb"></span>
                                 </div>
                                 <div class="horizontal-divider-05" style="opacity: .1; background-color: black;"></div>
                                 <div class="flex-row">
-                                    <h1 class="main-text m-r-10">Language:</h1><span id="book-info-language"
+                                    <h1 class="main-text m-r-10" data-i18n="bookInformation.language">Language:</h1><span id="book-info-language"
                                         class="main-text text-sb"></span>
                                 </div>
                                 <div class="horizontal-divider-05" style="opacity: .1; background-color: black;"></div>
                                 <div class="flex-row">
-                                    <h1 class="main-text m-r-10">Year Edition:</h1><span id="book-info-year"
+                                    <h1 class="main-text m-r-10" data-i18n="bookInformation.year">Year Edition:</h1><span id="book-info-year"
                                         class="main-text text-sb"></span>
                                 </div>
                                 <div class="horizontal-divider-05" style="opacity: .1; background-color: black;"></div>
                                 <div class="flex-row">
-                                    <h1 class="main-text m-r-10">Pages:</h1><span id="book-info-pages"
+                                    <h1 class="main-text m-r-10" data-i18n="bookInformation.pages">Pages:</h1><span id="book-info-pages"
                                         class="main-text text-sb"></span>
                                 </div>
                             </div>
@@ -174,10 +199,10 @@
                                 </div>
                                 <div class="horizontal-divider-05" style="background-color: black;"></div>
                                 <div class="flex-row flex-v-center" style="margin-top: 20px;">
-                                    <h1 class="main-text m-r-10">Typeface:</h1>
+                                    <h1 class="main-text m-r-10" data-i18n="readingSettings.typeface">Typeface:</h1>
                                     <div id="typeface-settings" class="w-100" onclick="handleTypeFaceSelection()">
                                         <div id="typeface-section" class="flex-row flex-v-center">
-                                            <h1 id="typeface-section-text" class="flex-1 main-text text-sb">Default</h1>
+                                            <h1 id="typeface-section-text" class="flex-1 main-text text-sb" data-i18n="readingSettings.default">Default</h1>
                                             <svg width="12" height="8" viewBox="0 0 8 4" fill="none"
                                                 xmlns="http://www.w3.org/2000/svg">
                                                 <path
@@ -197,7 +222,7 @@
                                     </div>
                                 </div>
                                 <div class="flex-row flex-v-center" style="margin-top: 20px;">
-                                    <h1 class="main-text m-r-10">Color Style:</h1>
+                                    <h1 class="main-text m-r-10" data-i18n="readingSettings.colorStyle">Color Style:</h1>
                                     <div class="flex-row flex-v-center flex-h-center">
                                         <div id="page-color-style-default" class="cursor-pointer"
                                             onclick="loadBookStyleSettings('default');"></div>
@@ -318,7 +343,7 @@
         </div>
         <div id="currentPagesContainer" class="w-100 flex-row flex-h-center py-8">
             <div id="currentPages" class="w-100 flex-row flex-h-center">
-                <h1 class="main-text"><span id="current_page_value" class="text-sb"></span> of <span
+                <h1 class="main-text"><span id="current_page_value" class="text-sb"></span><span  data-i18n="currentPageOf"> of </span><span
                         id="total_page_value"></span></h1>
             </div>
         </div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -16,6 +16,7 @@
   <script src="../js/general/dropFile.js"></script>
   <script src="../js/dashboard/dashboard.js"></script>
   <script src="../js/dashboard/sectionBookHandler.js"></script>
+    <script src="../js/general/rendererI18n.js" defer></script>
 </head>
 
 <body>
@@ -31,12 +32,12 @@
       </svg>
       <div class="flex flex-col mt-6 gap-5 w-[250px]">
         <div class="flex flex-row items-center">
-          <h1 class="main-text font-bold mr-3 text-white ">App version:</h1>
+          <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.appVersion">App version:</h1>
           <h1 id="app-info-version" class="main-text text-white "></h1>
         </div>
         <div class="h-[.5px] w-full bg-white opacity-10"></div>
         <div class="flex items-center flex-wrap">
-          <h1 class="main-text font-bold mr-3 text-white ">Author:</h1>
+          <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.author">Author:</h1>
           <div class="flex flex-row items-center">
             <img src="https://avatars.githubusercontent.com/u/40722616?v=4" alt="github logo" />
             <h1
@@ -49,18 +50,18 @@
         </div>
         <div class="h-[.5px] w-full bg-white opacity-10"></div>
         <div id="contributors-section">
-          <h1 class="main-text font-bold mr-3 text-white">Contributors:</h1>
+          <h1 class="main-text font-bold mr-3 text-white"  data-i18n="applicationInformation.contributors">Contributors:</h1>
           <ul id="contributors-list" class="main-text text-color-white"></ul>
         </div>        
         <div class="h-[.5px] w-full bg-white opacity-10"></div>
         <div>
-          <h1 class="main-text font-bold mr-3 text-white inline">Description:</h1>
-          <h1 id="app-info-description" class="main-text text-white inline">Epub Reader Application built with
+          <h1 class="main-text font-bold mr-3 text-white inline"  data-i18n="applicationInformation.description">Description:</h1>
+          <h1 id="app-info-description" class="main-text text-white inline"  data-i18n="applicationInformation.descriptionMessage">Epub Reader Application built with
             ElectronJS</h1>
         </div>
         <div class="h-[.5px] w-full bg-white opacity-10"></div>
         <div class="flex-row flex-v-center">
-          <h1 class="main-text font-bold mr-3 text-white ">Git Repository:</h1>
+          <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.gitRepository">Git Repository:</h1>
           <svg xmlns="http://www.w3.org/2000/svg" class="cursor-pointer"
             onclick="window.open('https://github.com/a5ur4/EpubReaderRedo','_blank')" version="1.1"
             xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" width="20" height="20" x="0"
@@ -115,23 +116,23 @@
             <img id="edit-book-information-cover" src="" alt="book cover" />
           </div>
           <div class="flex flex-col gap-3 flex-1">
-            <span class="main-text text-white font-semibold">Title</span>
+            <span class="main-text text-white font-semibold" data-i18n="bookInformation.title">Title</span>
             <input id="edit-book-information-title" type="text"
               class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-            <span class="main-text text-white font-semibold">Author</span>
+            <span class="main-text text-white font-semibold" data-i18n="bookInformation.author">Author</span>
             <input id="edit-book-information-author" type="text"
               class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-            <span class="main-text text-white font-semibold">Language</span>
+            <span class="main-text text-white font-semibold" data-i18n="bookInformation.language">Language</span>
             <input id="edit-book-information-language" type="text"
               class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-            <span class="main-text text-white font-semibold">Year</span>
+            <span class="main-text text-white font-semibold" data-i18n="bookInformation.year">Year</span>
             <input id="edit-book-information-year" type="text"
               class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
             <div class="flex-1 flex">
               <button id="edit-book-information-apply-btn"
                 class="main-text w-full flex-0 self-end text-white font-bold bg-[#18C34D] py-3 px-5 rounded-md"
                 onclick="event.stopPropagation(); applyEditEpubBookHandler($(this).data('folderbookcode'));"><span
-                  class="drop-shadow-md">Apply edit</span></button>
+                  class="drop-shadow-md" data-i18n="bookInformation.applyEdit">Apply edit</span></button>
             </div>
           </div>
         </div>
@@ -152,13 +153,13 @@
       </g>
     </svg>
 
-    <span class="main-text text-white">Drop file here</span>
+    <span class="main-text text-white" data-i18n="dropArea.dropFileHere">Drop file here</span>
   </div>
   <div id="main-navbar" class="absolute p-7 flex justify-between items-center z-[50] w-full select-none">
     <div class="flex flex-row items-center gap-7 no-drag">
       <div class="flex flex-col relative">
         <div id="settings-menu-open" class="flex flex-row items-center cursor-pointer">
-          <h1 class="main-text text-white mr-1">Settings</h1>
+          <h1 class="main-text text-white mr-1" data-i18n="settingsMenu.settings">Settings</h1>
           <svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
             <line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="white" stroke-linecap="round" />
             <line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="white" stroke-linecap="round" />
@@ -181,7 +182,33 @@
                 </g>
               </g>
             </svg>
-            <h1 class="main-text text-white ml-2">App information</h1>
+            <h1 class="main-text text-white ml-2" data-i18n="settingsMenu.appInformation">App information</h1>
+          </div>
+        </div>
+      </div>
+      <div class="vertical-divider-05 bg-white"></div>
+      <div class="flex flex-col relative">
+        <div id="language-menu-open" class="flex flex-row items-center cursor-pointer">
+          <h1 class="main-text text-white mr-1">EN</h1>
+          <svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="white" stroke-linecap="round" />
+            <line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="white" stroke-linecap="round" />
+          </svg>
+        </div>
+        <div id="language-menu"
+          class="p-6 mt-10 hidden absolute z-[10] flex flex-col gap-7 rounded-md bg-[#121212] shadow-md overflow-hidden w-fit">
+          <div id="menu-open-languages"
+            class="flex flex-col items-center transition opacity-80 hover:opacity-100 cursor-pointer">
+            <div>
+              <button class="button-language" onclick="defineCurrentLanguage('en')">
+                <h1 class="main-text text-white ml-2">EN</h1>
+              </button>
+            </div>
+            <div>
+              <button class="button-language" onclick="defineCurrentLanguage('ptBR')">
+                <h1 class="main-text text-white ml-2">PT-BR</h1>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -236,10 +263,10 @@
     <div class="flex flex-row justify-between">
       <div class="flex flex-row items-center">
         <div class="flex flex-row items-center">
-          <h1 class="main-text mr-1">Sort by: </h1>
+          <h1 class="main-text mr-1" data-i18n="bookSortings.sortBy">Sort by: </h1>
           <div class="flex flex-col">
             <div id="section-book-choose-sorting" class="flex flex-row items-center cursor-pointer">
-              <h1 id="section-book-current-sorting" class="main-text font-bold mr-1" data-sort="last_read">Last Read
+              <h1 id="section-book-current-sorting" class="main-text font-bold mr-1" data-sort="last_read" data-i18n="bookSortings.lastRead">Last Read
               </h1>
               <svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="black" stroke-linecap="round" />
@@ -250,11 +277,11 @@
               class="p-0 mt-8 list-none hidden absolute z-[15] rounded-md bg-white shadow-[0_0_6px_1px_rgba(0,0,0,.1)] overflow-hidden">
               <li
                 class="main-text font-bold py-2.5 px-5 transition hover:bg-[#ebebeb] cursor-pointer last-of-type:border-[1px_solid_rgba(0,0,0,0.1)]"
-                value="last_read">Last Read</li>
+                value="last_read" data-i18n="bookSortings.lastRead">Last Read</li>
               <li
                 class="main-text font-bold py-2.5 px-5 transition hover:bg-[#ebebeb] cursor-pointer last-of-type:border-[1px_solid_rgba(0,0,0,0.1)]"
-                value="alphabetically">Alphabetically</li>
-              <!-- <li class="main-text text-b" value="last_opened">Last Opened</li> -->
+                value="alphabetically" data-i18n="bookSortings.alphabetically">Alphabetically</li>
+              <!-- <li class="main-text text-b" value="last_opened" data-i18n="bookSortings.lastOpened">Last Opened</li> -->
             </ul>
           </div>
         </div>

--- a/src/pages/library.html
+++ b/src/pages/library.html
@@ -15,6 +15,7 @@
     <script src="../js/general/dropFile.js"></script>
     <script src="../js/library/library.js"></script>
     <script src="../js/library/sortingSettingsHandler.js"></script>
+    <script src="../js/general/rendererI18n.js" defer></script>
 </head>
 <body>
 	<h1 id="alert-text" class="main-text font-semibold text-white alert-default"></h1>
@@ -27,22 +28,36 @@
           </svg>
           <div class="flex flex-col mt-6 gap-5 w-[250px]">
             <div class="flex flex-row items-center">
-              <h1 class="main-text font-bold mr-3 text-white ">App version:</h1>
-              <h1 id="app-info-version" class="main-text text-white "></h1>
-            </div>
-			<div class="h-[.5px] w-full bg-white opacity-10"></div>
-            <div class="flex items-center flex-wrap">
-              <h1 class="main-text font-bold mr-3 text-white ">Author:</h1>
-              <h1 id="app-info-author" class="main-text text-color-white cursor-pointer" onclick="window.open('https://github.com/mignaway','_blank')" style="text-decoration: underline; display: ;">mignaway</h1>
-            </div>
-			<div class="h-[.5px] w-full bg-white opacity-10"></div>
-            <div>
-              <h1 class="main-text font-bold mr-3 text-white inline">Description:</h1>
-			  <h1 id="app-info-description" class="main-text text-white inline">Epub Reader Application built with ElectronJS</h1>
+              <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.appVersion">App version:</h1>
+          <h1 id="app-info-version" class="main-text text-white "></h1>
+        </div>
+        <div class="h-[.5px] w-full bg-white opacity-10"></div>
+        <div class="flex items-center flex-wrap">
+          <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.author">Author:</h1>
+          <div class="flex flex-row items-center">
+            <img src="https://avatars.githubusercontent.com/u/40722616?v=4" alt="github logo" />
+            <h1
+            id="app-info-author" class="main-text text-color-white cursor-pointer"
+            onclick="window.open('https://github.com/mignaway','_blank')"
+            style="text-decoration: underline; display: ;">
+              mignaway
+            </h1>
+          </div>
+        </div>
+        <div class="h-[.5px] w-full bg-white opacity-10"></div>
+        <div id="contributors-section">
+          <h1 class="main-text font-bold mr-3 text-white"  data-i18n="applicationInformation.contributors">Contributors:</h1>
+          <ul id="contributors-list" class="main-text text-color-white"></ul>
+        </div>        
+        <div class="h-[.5px] w-full bg-white opacity-10"></div>
+        <div>
+          <h1 class="main-text font-bold mr-3 text-white inline"  data-i18n="applicationInformation.description">Description:</h1>
+          <h1 id="app-info-description" class="main-text text-white inline"  data-i18n="applicationInformation.descriptionMessage">Epub Reader Application built with
+            ElectronJS</h1>
             </div>
 			<div class="h-[.5px] w-full bg-white opacity-10"></div>
             <div class="flex-row flex-v-center">
-              <h1 class="main-text font-bold mr-3 text-white ">Git Repository:</h1>
+              <h1 class="main-text font-bold mr-3 text-white " data-i18n="applicationInformation.gitRepository">Git Repository:</h1>
               <svg xmlns="http://www.w3.org/2000/svg" class="cursor-pointer" onclick="window.open('https://github.com/mignaway/EpubReader','_blank')" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:svgjs="http://svgjs.com/svgjs" width="20" height="20" x="0" y="0" viewBox="0 0 512.092 512.092"
                 style="enable-background:new 0 0 512 512" xml:space="preserve" class="">
@@ -84,16 +99,16 @@
 						<img id="edit-book-information-cover" src="" alt="book cover" />
 					</div>
 					<div class="flex flex-col gap-3 flex-1">
-						<span class="main-text text-white font-semibold">Title</span>
+						<span class="main-text text-white font-semibold" data-i18n="bookInformation.title">Title</span>
 						<input id="edit-book-information-title" type="text" class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-						<span class="main-text text-white font-semibold">Author</span>
+						<span class="main-text text-white font-semibold" data-i18n="bookInformation.author">Author</span>
 						<input id="edit-book-information-author" type="text" class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-						<span class="main-text text-white font-semibold">Language</span>
+						<span class="main-text text-white font-semibold" data-i18n="bookInformation.language">Language</span>
 						<input id="edit-book-information-language" type="text" class="main-text text-white bg-white/10 py-3 px-5 rounded-md">
-						<span class="main-text text-white font-semibold">Year</span>
+						<span class="main-text text-white font-semibold" data-i18n="bookInformation.year">Year</span>
 						<input id="edit-book-information-year" type="text" class="main-text text-white bg-white/10 py-3 px-5 rounded-md" >
 						<div class="flex-1 flex">
-							<button id="edit-book-information-apply-btn" class="main-text w-full flex-0 self-end text-white font-bold bg-[#18C34D] py-3 px-5 rounded-md" onclick="event.stopPropagation(); applyEditEpubBookHandler($(this).data('folderbookcode'));"><span class="drop-shadow-md">Apply edit</span></button>
+							<button id="edit-book-information-apply-btn" class="main-text w-full flex-0 self-end text-white font-bold bg-[#18C34D] py-3 px-5 rounded-md" onclick="event.stopPropagation(); applyEditEpubBookHandler($(this).data('folderbookcode'));"><span class="drop-shadow-md" data-i18n="bookInformation.applyEdit">Apply edit</span></button>
 						</div>
 					</div>
 				</div>
@@ -107,7 +122,7 @@
 			<path d="M58.3333 64.0417C58.3146 62.8854 57.0792 62.9688 56.25 63V65.0834C57.0792 65.1125 58.3146 65.2 58.3333 64.0417ZM58.3333 70.2917C58.3146 69.1354 57.0792 69.2188 56.25 69.25V71.3334C57.0792 71.3625 58.3146 71.45 58.3333 70.2917Z" fill="white" fill-opacity="0.75"/>
 			<path d="M12.5 52.5835C11.9474 52.5835 11.4175 52.803 11.0268 53.1937C10.6361 53.5844 10.4166 54.1143 10.4166 54.6668V79.6668C10.4166 80.2194 10.6361 80.7493 11.0268 81.14C11.4175 81.5307 11.9474 81.7502 12.5 81.7502H66.6666C67.2192 81.7502 67.7491 81.5307 68.1398 81.14C68.5305 80.7493 68.75 80.2194 68.75 79.6668V54.6668C68.75 54.1143 68.5305 53.5844 68.1398 53.1937C67.7491 52.803 67.2192 52.5835 66.6666 52.5835H12.5ZM52.0833 60.9168C52.0833 60.3643 52.3028 59.8344 52.6935 59.4437C53.0842 59.053 53.6141 58.8335 54.1666 58.8335H57.2916C60.1645 58.8335 62.5 61.1689 62.5 64.0418C62.5 65.2147 62.1104 66.296 61.4562 67.1668C62.1104 68.0377 62.5 69.121 62.5 70.2918C62.5 73.1647 60.1645 75.5002 57.2916 75.5002H54.1666C53.6141 75.5002 53.0842 75.2807 52.6935 74.89C52.3028 74.4993 52.0833 73.9694 52.0833 73.4168V60.9168ZM39.5833 60.9168C39.5958 58.1939 43.7375 58.1897 43.75 60.9168V70.2918C43.75 70.5681 43.8597 70.833 44.0551 71.0284C44.2504 71.2237 44.5154 71.3335 44.7916 71.3335C45.0679 71.3335 45.3328 71.2237 45.5282 71.0284C45.7235 70.833 45.8333 70.5681 45.8333 70.2918V60.9168C45.8333 60.3643 46.0528 59.8344 46.4435 59.4437C46.8342 59.053 47.3641 58.8335 47.9166 58.8335C48.4692 58.8335 48.9991 59.053 49.3898 59.4437C49.7805 59.8344 50 60.3643 50 60.9168V70.2918C49.8208 77.1564 39.7625 77.1606 39.5833 70.2918V60.9168ZM27.0833 60.9168C27.0833 60.3643 27.3028 59.8344 27.6935 59.4437C28.0842 59.053 28.6141 58.8335 29.1666 58.8335H32.2916C39.1583 59.0147 39.1583 69.071 32.2916 69.2502H31.25V73.4168C31.2395 76.1377 27.0937 76.1439 27.0833 73.4168V60.9168ZM22.9166 58.8335C25.6416 58.8481 25.6416 62.9877 22.9166 63.0002H20.8333V65.0835H22.9166C25.6395 65.0939 25.6416 69.2397 22.9166 69.2502H20.8333V71.3335H22.9166C23.4692 71.3335 23.9991 71.553 24.3898 71.9437C24.7805 72.3344 25 72.8643 25 73.4168C25 73.9694 24.7805 74.4993 24.3898 74.89C23.9991 75.2807 23.4692 75.5002 22.9166 75.5002H18.75C18.1974 75.5002 17.6675 75.2807 17.2768 74.89C16.8861 74.4993 16.6666 73.9694 16.6666 73.4168V60.9168C16.6666 60.3643 16.8861 59.8344 17.2768 59.4437C17.6675 59.053 18.1974 58.8335 18.75 58.8335H22.9166Z" fill="white" fill-opacity="0.75"/>
 		</svg>
-		<span class="main-text text-white">Drop file here</span>	
+		<span class="main-text text-white" data-i18n="dropArea.dropFileHere">Drop file here</span>	
 	</div>
     
     <div class="flex flex-col h-full">
@@ -115,7 +130,7 @@
 			<div class="flex flex-row items-center gap-7 no-drag">
 				<div class="flex flex-col relative">
 					<div id="settings-menu-open" class="flex flex-row items-center cursor-pointer">
-						<h1 class="main-text mr-1 font-semibold">Settings</h1>
+						<h1 class="main-text mr-1 font-semibold" data-i18n="settingsMenu.settings">Settings</h1>
 						<svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
 							<line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="black" stroke-linecap="round" />
 							<line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="black" stroke-linecap="round" />
@@ -136,7 +151,31 @@
 								</g>
 								</g>
 							</svg>
-							<h1 class="main-text text-white ml-2">App information</h1>
+							<h1 class="main-text text-white ml-2" data-i18n="settingsMenu.appInformation">App information</h1>
+						</div>
+					</div>
+				</div>
+				<div class="vertical-divider-05 bg-black"></div>
+				<div class="flex flex-col relative">
+					<div id="language-menu-open" class="flex flex-row items-center cursor-pointer">
+						<h1 class="main-text mr-1 font-semibold">EN</h1>
+						<svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="black" stroke-linecap="round" />
+							<line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="black" stroke-linecap="round" />
+						</svg>
+					</div>
+					<div id="language-menu" class="p-6 mt-10 hidden absolute z-[10] flex flex-col gap-7 rounded-md bg-[#121212] shadow-md overflow-hidden w-fit">
+						<div id="menu-open-languages" class="flex flex-col items-center transition opacity-80 hover:opacity-100 cursor-pointer">
+              <div>
+                <button class="button-language" onclick="defineCurrentLanguage('en')">
+                  <h1 class="main-text text-white ml-2">EN</h1>
+                </button>
+              </div>
+              <div>
+                <button class="button-language" onclick="defineCurrentLanguage('ptBR')">
+                  <h1 class="main-text text-white ml-2">PT-BR</h1>
+                </button>
+              </div>
 						</div>
 					</div>
 				</div>
@@ -177,7 +216,7 @@
                             d="M19.5 7.9C19.9971 7.9 20.4 7.49706 20.4 7C20.4 6.50294 19.9971 6.1 19.5 6.1L19.5 7.9ZM0.363604 6.3636C0.012132 6.71507 0.012132 7.28492 0.363604 7.63639L6.09117 13.364C6.44264 13.7154 7.01249 13.7154 7.36396 13.364C7.71543 13.0125 7.71543 12.4426 7.36396 12.0912L2.27279 7L7.36396 1.90883C7.71543 1.55736 7.71543 0.98751 7.36396 0.636038C7.01249 0.284566 6.44264 0.284566 6.09117 0.636038L0.363604 6.3636ZM19.5 6.1L1 6.1L1 7.9L19.5 7.9L19.5 6.1Z"
                             fill="black" />
                     </svg>
-                    <h1 class="main-text font-semibold">Back to dashboard</h1>
+                    <h1 class="main-text font-semibold" data-i18n="sidebarSettings.BackToDashboard">Back to dashboard</h1>
                 </a>
                 <div id="search-bar-container" class="bg-[#F3F3F3] py-4 px-5 rounded-md m-0 mt-7">
                     <div id="search-bar" class="flex flex-row gap-4 items-center">
@@ -187,28 +226,28 @@
                              />
                         </svg>
                         <div class="w-[.5px] h-[20px] bg-black opacity-10"></div>
-                        <input id="search-bar-input" class="main-text bg-transparent text-base w-full flex-1" type="text" onkeyup="handleSearchBarChange(this.value)" placeholder="Search books..." />
+                        <input id="search-bar-input" class="main-text bg-transparent text-base w-full flex-1" type="text" onkeyup="handleSearchBarChange(this.value)" placeholder="Search books..." data-i18n-placeholder="sidebarSettings.searchBooks" />
                     </div>
                 </div>
                 <div id="sorting-settings" class="flex flex-col py-7 gap-7">
-                    <h1 class="main-text text-2xl font-semibold">Sorting</h1>
+                    <h1 class="main-text text-2xl font-semibold" data-i18n="bookSortings.sorting">Sorting</h1>
                     <div class="flex flex-row items-center">
-                        <h1 class="main-text mr-2.5 whitespace-nowrap">Sort By:</h1>
+                        <h1 class="main-text mr-2.5 whitespace-nowrap" data-i18n="bookSortings.sortBy">Sort By:</h1>
                         <div class="flex flex-col">
                             <div class="sorting-settings-choose cursor-pointer py-2.5 px-5 rounded-[5px] bg-[#F3F3F3] flex flex-row items-center">
-                                <h1 id="sorting-settings-current-sortby" class="sorting-settings-current-text main-text font-bold mr-1" data-sort="last_read">Last Read</h1>
+                                <h1 id="sorting-settings-current-sortby" class="sorting-settings-current-text main-text font-bold mr-1" data-sort="last_read" data-i18n="bookSortings.lastRead">Last Read</h1>
                                 <svg width="12" height="7" viewBox="0 0 7 5" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <line x1="0.707107" y1="1" x2="3.5" y2="3.79289" stroke="black" stroke-linecap="round" />
                                     <line x1="3.5" y1="3.79289" x2="6.29289" y2="1" stroke="black" stroke-linecap="round" />
                                 </svg>
                             </div>
                             <ul class="sorting-settings-list p-0 mt-12 list-none hidden absolute z-10 rounded-[5px] bg-white shadow-[0_0_6px_1px_rgba(0,0,0,.1)] overflow-hidden" data-settings="sortby">
-                                <li class="main-text font-bold py-2.5 px-5 transition cursor-pointer hover:bg-[#EBEBEB]" value="last_read">Last Read</li>
-                                <li class="main-text font-bold py-2.5 px-5 transition cursor-pointer hover:bg-[#EBEBEB]" value="alphabetically">Alphabetically</li>
+                                <li class="main-text font-bold py-2.5 px-5 transition cursor-pointer hover:bg-[#EBEBEB]" value="last_read" data-i18n="bookSortings.lastRead">Last Read</li>
+                                <li class="main-text font-bold py-2.5 px-5 transition cursor-pointer hover:bg-[#EBEBEB]" value="alphabetically" data-i18n="bookSortings.alphabetically">Alphabetically</li>
                             </ul>
                         </div>
                     </div>
-                    <button id="sorting-apply-btn" class="primary-button bg-black">Apply changes</button>
+                    <button id="sorting-apply-btn" class="primary-button bg-black" data-i18n="bookSortings.applyChanges">Apply changes</button>
                 </div>
             </div>
             <div id="books-section" class="flex flex-col pt-7 px-7 relative flex-1 overflow-hidden">

--- a/src/preload.js
+++ b/src/preload.js
@@ -5,6 +5,7 @@ const Vibrant = require('node-vibrant');
 const Epub = require("epub2").EPub;
 const path = require('path');
 const convert = require('ebook-convert')
+const i18n = require('./i18n/i18n.js')
 
 // Define allowed extensions for books
 const allowedExtensions = ['epub','pdf','mobi'];
@@ -326,4 +327,10 @@ contextBridge.exposeInMainWorld('appConfig', {
     async invoke(eventName, ...params) {
         return await ipcRenderer.invoke(eventName, ...params)
     },
+});
+
+contextBridge.exposeInMainWorld("i18n", {
+  t: (key) => i18n.t(key),
+  changeLanguage: (lang, callback) => i18n.changeLanguage(lang, callback),
+  setLang: (lang) => i18n.load(lang),
 });


### PR DESCRIPTION
**This PR introduces:**
- A basic **language switch system (i18n)** and the **Portuguese (pt-BR)** translation files.
- Integration of translations in both HTML and JavaScript.

**Translation notes**
- **"Sorting"** was translated as **"Ordem"** (meaning Order in English). It’s understandable, though it could be refined later.
- **"Last Opened"** was translated literally as **"Última Abertura"**, which might sound slightly unnatural — open to suggestions.
- For book information, **"Year"** (in index.html and library.html) was replaced with **"Year Edition:"** as used in book.html, for consistency.
- In book.html, " of " was wrapped in a <span> to make i18n integration easier, avoiding JavaScript changes.

**JavaScript adjustments**
- **dashboard.js**
  - Added i18n support for:
  - "Keep reading" / "Start reading"
  - "No preview available."
  - "Add books by clicking the '+' button"
- **book.js**
  - Added i18n support for:
  - "Highlight some text to know its definition!"
  - "Remember to search for only one word at a time"
  - "no page saved"

**Other notes**
- Additional small translation-related adaptations throughout the code.
- In book.html, translation was not applied to the Dictionary Language section since it’s currently commented out.